### PR TITLE
Import future annotations & fix type for `Toast.__init__` `parent` argument 

### DIFF
--- a/src/pyqttoast/icon_utils.py
+++ b/src/pyqttoast/icon_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from qtpy.QtGui import QPixmap, QColor, QImage, qRgba
 from .toast_enums import ToastIcon
 from .os_utils import OSUtils

--- a/src/pyqttoast/toast.py
+++ b/src/pyqttoast/toast.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 from qtpy.QtGui import QGuiApplication, QScreen
 from qtpy.QtCore import Qt, QPropertyAnimation, QPoint, QTimer, QSize, QMargins, QRect, Signal

--- a/src/pyqttoast/toast.py
+++ b/src/pyqttoast/toast.py
@@ -29,7 +29,7 @@ class Toast(QDialog):
     # Close event
     closed = Signal()
 
-    def __init__(self, parent: QWidget = None):
+    def __init__(self, parent: QWidget | None = None):
         """Create a new Toast instance
 
         :param parent: the parent widget


### PR DESCRIPTION
Added imports:
`from __future__ import annotations` 
To make the union operator work in python versions below 3.10 #23 

Also typed the `parent` argument in `Toast.__init__` as optional,
otherwise `Toast(None)` throws linting errors even though the code is valid

Thanks for this really neat package!